### PR TITLE
feat: add option to increment/decrement in for loops

### DIFF
--- a/docs/rules/no-mutation.md
+++ b/docs/rules/no-mutation.md
@@ -10,6 +10,8 @@ This rule supports the following options:
 
 `allowThis`: If set to `true`, then this rule will not report when assigning to or to a (sub-) property of `this`.
 
+`allowUnaryOperatorInForLoops`: If set to `true`, then this rule will not report increment/decrement operations in the update statement of a `for` loop
+
 `exceptions`: List of objects that describe exceptions to the rule. Each exception should have either or both `object` and `property` field set.
 
 `prototypes`: If set to `true`, then this rule will permit assignment to the `prototype` of an object.

--- a/rules/no-mutation.js
+++ b/rules/no-mutation.js
@@ -133,6 +133,7 @@ const create = function (context) {
       if (options.allowUnaryOperatorInForLoops && isForLoopAfterthought(node)) {
         return;
       }
+
       context.report({
         node,
         messageId: 'unsafeMutatingOperator',

--- a/rules/no-mutation.js
+++ b/rules/no-mutation.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _ = require('lodash/fp');
-const {isScopedVariable, isScopedFunction, isExemptedReducer, isScopedLetVariableAssignment} = require('./utils/common');
+const {isScopedVariable, isScopedFunction, isExemptedReducer, isScopedLetVariableAssignment, isForLoopAfterthought} = require('./utils/common');
 const {defaultReducers, defaultInitializers} = require('./utils/defaults');
 
 const isModuleExports = _.matches({
@@ -130,6 +130,9 @@ const create = function (context) {
       });
     },
     UpdateExpression(node) {
+      if (options.allowUnaryOperatorInForLoops && isForLoopAfterthought(node)) {
+        return;
+      }
       context.report({
         node,
         messageId: 'unsafeMutatingOperator',
@@ -152,6 +155,9 @@ module.exports = {
           type: 'boolean',
         },
         allowThis: {
+          type: 'boolean',
+        },
+        allowUnaryOperatorInForLoops: {
           type: 'boolean',
         },
         prototypes: {

--- a/rules/utils/common.js
+++ b/rules/utils/common.js
@@ -259,9 +259,9 @@ function isExemptedReducer(exemptedReducerCallees, node) {
  * @author Brody McKee (github.com/mrmckeb)
  */
 function isForStatementUpdate(node) {
-  const parent = node.parent;
+  const {parent} = node;
 
-  return parent.type === "ForStatement" && parent.update === node;
+  return parent.type === 'ForStatement' && parent.update === node;
 }
 
 /**
@@ -277,10 +277,10 @@ function isForStatementUpdate(node) {
  * @author Brody McKee (github.com/mrmckeb)
  */
 function isForLoopAfterthought(node) {
-  const parent = node.parent;
+  const {parent} = node;
 
-  if (parent.type === "SequenceExpression") {
-      return isForLoopAfterthought(parent);
+  if (parent.type === 'SequenceExpression') {
+    return isForLoopAfterthought(parent);
   }
 
   return isForStatementUpdate(node);

--- a/rules/utils/common.js
+++ b/rules/utils/common.js
@@ -251,6 +251,41 @@ function isExemptedReducer(exemptedReducerCallees, node) {
   return callee && _.includes(_.getOr(_.get('name', callee), 'property.name', callee), exemptedReducerCallees);
 }
 
+/**
+ * Determines whether the given node is the update node of a `ForStatement`.
+ * @param {ASTNode} node The node to check.
+ * @returns {boolean} `true` if the node is `ForStatement` update.
+ * @author Ian Christian Myers
+ * @author Brody McKee (github.com/mrmckeb)
+ */
+function isForStatementUpdate(node) {
+  const parent = node.parent;
+
+  return parent.type === "ForStatement" && parent.update === node;
+}
+
+/**
+ * Determines whether the given node is considered to be a for loop "afterthought" by the logic of this rule.
+ * In particular, it returns `true` if the given node is either:
+ *   - The update node of a `ForStatement`: for (;; i++) {}
+ *   - An operand of a sequence expression that is the update node: for (;; foo(), i++) {}
+ *   - An operand of a sequence expression that is child of another sequence expression, etc.,
+ *     up to the sequence expression that is the update node: for (;; foo(), (bar(), (baz(), i++))) {}
+ * @param {ASTNode} node The node to check.
+ * @returns {boolean} `true` if the node is a for loop afterthought.
+ * @author Ian Christian Myers
+ * @author Brody McKee (github.com/mrmckeb)
+ */
+function isForLoopAfterthought(node) {
+  const parent = node.parent;
+
+  if (parent.type === "SequenceExpression") {
+      return isForLoopAfterthought(parent);
+  }
+
+  return isForStatementUpdate(node);
+}
+
 module.exports = {
   isExemptedReducer,
   isFunctionExpression,
@@ -259,4 +294,5 @@ module.exports = {
   isScopedFunction,
   isScopedVariable,
   isValidInit,
+  isForLoopAfterthought,
 };

--- a/test/no-mutation.js
+++ b/test/no-mutation.js
@@ -165,6 +165,22 @@ ruleTester.run('no-mutation', rule, {
       code: 'const x = MyObject.init(42); x.foo += 1',
       options: [{initializers: ['MyObject.init']}],
     },
+    {
+      code: 'for(let i = 0; i < 0; i++){}',
+      options: [{allowUnaryOperatorInForLoops: true}],
+    },
+    {
+      code: 'for(let i = 0; i < 0; ++i){}',
+      options: [{allowUnaryOperatorInForLoops: true}],
+    },
+    {
+      code: 'for(let i = 3; i > 0; i--){}',
+      options: [{allowUnaryOperatorInForLoops: true}],
+    },
+    {
+      code: 'for(let i = 3; i > 0; --i){}',
+      options: [{allowUnaryOperatorInForLoops: true}],
+    },
   ],
   invalid: [
     {
@@ -217,6 +233,26 @@ ruleTester.run('no-mutation', rule, {
     },
     {
       code: '--a;',
+      errors: [decrementError],
+    },
+    {
+      code: 'for(let i = 0; ++i < 3; ){}',
+      options: [{allowUnaryOperatorInForLoops: true}],
+      errors: [incrementError],
+    },
+    {
+      code: 'for(let i = 0; i++ < 3; ){}',
+      options: [{allowUnaryOperatorInForLoops: true}],
+      errors: [incrementError],
+    },
+    {
+      code: 'for(let i = 3; --i > 0; ){}',
+      options: [{allowUnaryOperatorInForLoops: true}],
+      errors: [decrementError],
+    },
+    {
+      code: 'for(let i = 3; i-- > 0; ){}',
+      options: [{allowUnaryOperatorInForLoops: true}],
       errors: [decrementError],
     },
     {


### PR DESCRIPTION
Hey @sloops77 

Thanks for the great work on the plugin! This PR adds an option to allow incrementing/decrementing in update statement of `for` loops you discussed with @zmilonas in https://github.com/sloops77/eslint-plugin-better-mutation/issues/122

I think your suggestion to use https://eslint.org/docs/latest/rules/no-plusplus is a great idea, so I decided to literally take that part of the code from `no-plusplus` and add here, so it works exactly the same

