### PR TITLE
fix: handle undefined exemptedInitializers

### DIFF
--- a/rules/utils/common.js
+++ b/rules/utils/common.js
@@ -288,6 +288,7 @@ function isForLoopAfterthought(node) {
 
 module.exports = {
   isExemptedReducer,
+  isExemptedInitializer,
   isFunctionExpression,
   isObjectExpression,
   isScopedLetVariableAssignment,

--- a/rules/utils/common.js
+++ b/rules/utils/common.js
@@ -65,7 +65,7 @@ const isExemptedInitializer = (rhsExpression, exemptedInitializers) => {
   }
 
   const initializer = buildInitializer(rhsExpression.callee);
-  if (exemptedInitializers.includes(initializer)) {
+  if (exemptedInitializers?.includes(initializer)) {
     return true;
   }
 

--- a/test/utils/common.js
+++ b/test/utils/common.js
@@ -1,8 +1,8 @@
 const test = require('ava');
-const { isExemptedInitializer } = require('../../rules/utils/common');
+const {isExemptedInitializer} = require('../../rules/utils/common');
 
 test('should return false if rhsExpression is not a CallExpression', t => {
-  const rhsExpression = { type: 'Literal' };
+  const rhsExpression = {type: 'Literal'};
   const exemptedInitializers = ['someFunction'];
   t.false(isExemptedInitializer(rhsExpression, exemptedInitializers));
 });
@@ -10,7 +10,7 @@ test('should return false if rhsExpression is not a CallExpression', t => {
 test('should return false if exemptedInitializers is null or undefined', t => {
   const rhsExpression = {
     type: 'CallExpression',
-    callee: { name: 'someFunction' },
+    callee: {name: 'someFunction'},
   };
   t.false(isExemptedInitializer(rhsExpression, null));
   t.false(isExemptedInitializer(rhsExpression, undefined));
@@ -19,7 +19,7 @@ test('should return false if exemptedInitializers is null or undefined', t => {
 test('should return true if exemptedInitializers contains the initializer', t => {
   const rhsExpression = {
     type: 'CallExpression',
-    callee: { name: 'someFunction' },
+    callee: {name: 'someFunction'},
   };
   const exemptedInitializers = ['someFunction'];
   t.true(isExemptedInitializer(rhsExpression, exemptedInitializers));
@@ -28,7 +28,7 @@ test('should return true if exemptedInitializers contains the initializer', t =>
 test('should return false if exemptedInitializers does not contain the initializer', t => {
   const rhsExpression = {
     type: 'CallExpression',
-    callee: { name: 'anotherFunction' },
+    callee: {name: 'anotherFunction'},
   };
   const exemptedInitializers = ['someFunction'];
   t.false(isExemptedInitializer(rhsExpression, exemptedInitializers));
@@ -40,7 +40,7 @@ test('should handle recursive cases with callee.object', t => {
     callee: {
       object: {
         type: 'CallExpression',
-        callee: { name: 'nestedFunction' },
+        callee: {name: 'nestedFunction'},
       },
     },
   };

--- a/test/utils/common.js
+++ b/test/utils/common.js
@@ -1,0 +1,49 @@
+const test = require('ava');
+const { isExemptedInitializer } = require('../../rules/utils/common');
+
+test('should return false if rhsExpression is not a CallExpression', t => {
+  const rhsExpression = { type: 'Literal' };
+  const exemptedInitializers = ['someFunction'];
+  t.false(isExemptedInitializer(rhsExpression, exemptedInitializers));
+});
+
+test('should return false if exemptedInitializers is null or undefined', t => {
+  const rhsExpression = {
+    type: 'CallExpression',
+    callee: { name: 'someFunction' },
+  };
+  t.false(isExemptedInitializer(rhsExpression, null));
+  t.false(isExemptedInitializer(rhsExpression, undefined));
+});
+
+test('should return true if exemptedInitializers contains the initializer', t => {
+  const rhsExpression = {
+    type: 'CallExpression',
+    callee: { name: 'someFunction' },
+  };
+  const exemptedInitializers = ['someFunction'];
+  t.true(isExemptedInitializer(rhsExpression, exemptedInitializers));
+});
+
+test('should return false if exemptedInitializers does not contain the initializer', t => {
+  const rhsExpression = {
+    type: 'CallExpression',
+    callee: { name: 'anotherFunction' },
+  };
+  const exemptedInitializers = ['someFunction'];
+  t.false(isExemptedInitializer(rhsExpression, exemptedInitializers));
+});
+
+test('should handle recursive cases with callee.object', t => {
+  const rhsExpression = {
+    type: 'CallExpression',
+    callee: {
+      object: {
+        type: 'CallExpression',
+        callee: { name: 'nestedFunction' },
+      },
+    },
+  };
+  const exemptedInitializers = ['nestedFunction'];
+  t.true(isExemptedInitializer(rhsExpression, exemptedInitializers));
+});


### PR DESCRIPTION
Hey @sloops77 

This PR adds a simple fix for a situation where `exemptedInitializers` is `null`/`undefined`.

It was causing ESLint to stop working correctly.