### PR TITLE
[codex] Disable Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
+# Dependabot security updates are handled separately from version updates.
+# Keep this npm entry so security updates can still use the repository config,
+# but disable routine dependency version update pull requests.
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
@@ -9,3 +9,4 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## Summary
- Disable routine Dependabot npm dependency version update PRs by setting open-pull-requests-limit to 0.
- Keep the Dependabot config in place so security update behavior remains available through GitHub security settings.

## Validation
- Parsed .github/dependabot.yml with Ruby YAML loader.