### PR TITLE
chore(release): prepare v3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-better-mutation",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "ESLint rules for controlling where and how mutation is used.",
   "license": "MIT",
   "repository": "sloops77/eslint-plugin-better-mutation",


### PR DESCRIPTION
## Summary

- bump `eslint-plugin-better-mutation` from 2.1.0 to 3.0.0
- mark the accumulated compatibility changes since v2.1.0 as a major release

## Breaking changes

- Node.js 18 and 20 are no longer supported; 3.0.0 requires `^22.20.0 || ^24.12.0 || >=26.0.0`
- ESLint 6–8 are no longer supported; 3.0.0 requires `^9.0.0 || ^10.0.0`

The plugin rules and options are otherwise unchanged from v2.1.0. Other accumulated maintenance includes updated runtime and development dependencies, migration from CircleCI to GitHub Actions, and Renovate-based dependency management.

## Validation

- `yarn install --frozen-lockfile`
- `yarn test` — 197 tests passed
- `yarn lint` — 0 errors; 4 pre-existing warnings
- `npm pack --dry-run --json` — package version 3.0.0 with 9 expected files

**Full comparison:** https://github.com/sloops77/eslint-plugin-better-mutation/compare/v2.1.0...codex/release-3.0.0