### PR TITLE
ci: use npm trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: Git ref containing the package version to publish
+        description: Release tag to publish (for example, v3.0.0)
         required: true
         type: string
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,21 +1,56 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+# Publish releases to npm with GitHub Actions OIDC trusted publishing.
 
 name: Node.js Package
 
 on:
   release:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref containing the package version to publish
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.release.tag_name }}
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: lts/*
+          node-version: 24.12.0
           registry-url: https://registry.npmjs.org/
-      - run: yarn publish
+          package-manager-cache: false
+
+      - name: Validate publish ref and tooling
         env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+          PUBLISH_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.release.tag_name }}
+        run: |
+          package_version="$(node --print "require('./package.json').version")"
+          expected_tag="v${package_version}"
+          npm_version="$(npm --version)"
+
+          node -e '
+            const [major = 0, minor = 0, patch = 0] = process.argv[1].split(".").map(Number);
+            const supported = major > 11
+              || (major === 11 && minor > 5)
+              || (major === 11 && minor === 5 && patch >= 1);
+            if (!supported) {
+              throw new Error("npm 11.5.1 or newer is required; found " + process.argv[1]);
+            }
+          ' "$npm_version"
+
+          if [[ "$PUBLISH_REF" == v* && "$PUBLISH_REF" != "$expected_tag" ]]; then
+            echo "Publish ref $PUBLISH_REF does not match package version $package_version" >&2
+            exit 1
+          fi
+
+      - run: npm publish

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,11 +18,12 @@ permissions:
 
 jobs:
   publish-npm:
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.release.tag_name }}
+          ref: refs/tags/${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.release.tag_name }}
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
@@ -48,7 +49,7 @@ jobs:
             }
           ' "$npm_version"
 
-          if [[ "$PUBLISH_REF" == v* && "$PUBLISH_REF" != "$expected_tag" ]]; then
+          if [[ "$PUBLISH_REF" != "$expected_tag" ]]; then
             echo "Publish ref $PUBLISH_REF does not match package version $package_version" >&2
             exit 1
           fi


### PR DESCRIPTION
## Summary

- replace the expired npm-token publish path with GitHub Actions OIDC trusted publishing
- allow recovery publishes through a required release-tag input while always checking out an immutable `refs/tags/*` ref
- restrict manual runs to the workflow on `master`, validate npm >= 11.5.1, and require the tag to match `package.json`
- pin Node 24.12.0, disable release-job package-manager caching, and remove `NODE_AUTH_TOKEN`

The npm package now trusts `sloops77/eslint-plugin-better-mutation` workflow `npm-publish.yml` for `npm publish`.

## Validation

- `actionlint .github/workflows/npm-publish.yml`
- exact `v3.0.0` accepted; branch, SHA, qualified, non-`v`, and mismatched refs rejected
- `corepack yarn install --frozen-lockfile`
- `corepack yarn test` (197 passed)
- `corepack yarn lint` (0 errors, 4 existing warnings)
- `npm pack --dry-run --json` (version 3.0.0, 9 files)
- `git diff --check`

After merge, recovery publish command:

```sh
gh workflow run npm-publish.yml \
  --repo sloops77/eslint-plugin-better-mutation \
  --ref master \
  -f ref=v3.0.0
```
