### PR TITLE
ci: simplify publish validation

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -31,23 +31,12 @@ jobs:
           registry-url: https://registry.npmjs.org/
           package-manager-cache: false
 
-      - name: Validate publish ref and tooling
+      - name: Validate publish ref
         env:
           PUBLISH_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.release.tag_name }}
         run: |
           package_version="$(node --print "require('./package.json').version")"
           expected_tag="v${package_version}"
-          npm_version="$(npm --version)"
-
-          node -e '
-            const [major = 0, minor = 0, patch = 0] = process.argv[1].split(".").map(Number);
-            const supported = major > 11
-              || (major === 11 && minor > 5)
-              || (major === 11 && minor === 5 && patch >= 1);
-            if (!supported) {
-              throw new Error("npm 11.5.1 or newer is required; found " + process.argv[1]);
-            }
-          ' "$npm_version"
 
           if [[ "$PUBLISH_REF" != "$expected_tag" ]]; then
             echo "Publish ref $PUBLISH_REF does not match package version $package_version" >&2


### PR DESCRIPTION
## Summary

- remove the redundant npm version parser from the trusted-publishing workflow
- keep Node 24.12.0 as the selected publishing runtime
- retain exact release-tag/package-version validation and immutable tag checkout

## Validation

- `actionlint .github/workflows/npm-publish.yml`
- `PUBLISH_REF=v3.0.0` accepted
- `PUBLISH_REF=master` rejected
- `corepack yarn test` (197 passed)
- `corepack yarn lint` (0 errors, 4 existing warnings)
- independent read-only review: ready to merge
